### PR TITLE
build(Project): Add html, js linting utilities, along with npm initia…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "standard"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Intelli-J
 .idea/
 theme.lock
+node_modules
+npm-debug.log

--- a/.htmllintrc
+++ b/.htmllintrc
@@ -1,0 +1,13 @@
+{
+    "attr-name-style": "dash",
+    "plugins": [],
+    "indent-style": "spaces",
+    "id-no-dup": true,
+    "id-class-style": false,
+    "line-end-style": false,
+    "tag-name-lowercase": true,
+    "line-no-trailing-whitespace": true,
+    "title-max-len": false,
+    "class-no-dup": true,
+    "raw-ignore-regex": "{{.*?}}|{%.*?%}"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Blendtec Shopify Theme
+
+Blendtec.com Shopify Theme
+
+## Getting Started
+
+  1. `$ git clone git@github.com:Blendtec/blendtec-shopify-theme.git`
+  2. `$ cd blendtec-shopify-theme`
+  3. `$ npm install`
+
+### Prerequisites
+
+  - [NodeJs](https://nodejs.org)
+  - NPM
+  - [Grunt-CLI](https://gruntjs.com)
+  - [Theme Kit](https://shopify.github.io/themekit/#installation) configured with your dev store instance
+
+## Workflow
+1. `$ git checkout -b <ISSUE-NUMBER> - name`
+2. `$ theme upload force`
+3. `$ theme watch`
+4. Hack on Code until feature is complete (committing sanely)
+5. `$ git push -u origin <Branch Name>`
+6. Create Pull Request
+
+
+### And coding style tests
+
+TODO
+
+## Deployment
+
+Deployment is handled via Travis-CI and occurs on stage and master branches

--- a/gulpFile.js
+++ b/gulpFile.js
@@ -1,0 +1,15 @@
+var gulp = require('gulp'),
+	htmlLint = require('gulp-html-lint');
+
+var htmlOptions = {
+	htmllintrc: '.htmllintrc',
+	useHtmllintrc: true,
+	plugins: []
+};
+
+gulp.task('linthtml', function() {
+	// return gulp.src('TODO')
+	// 	.pipe(htmlLint(htmlOptions))
+	// 	.pipe(htmlLint.format())
+	// 	.pipe(htmlLint.failOnError());
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "shopify-theme",
+  "version": "1.0.0",
+  "description": "Blendtec Shopify Theme",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:locale": "theme-lint ./",
+    "lint:layouts": "htmllint --rc ./.htmllintrc layout/* ",
+    "lint:sections": "htmllint --rc ./.htmllintrc sections/* ",
+    "lint:snippets": "htmllint --rc ./.htmllintrc snippets/* ",
+    "lint:html": "npm run lint:layouts && npm run lint:sections && npm run lint:snippets",
+    "lint:htmlfile": "htmllint --rc ./.htmllintrc",
+    "lint:js": "jslint assets/*.liquid",
+    "lint:jsfile": "jslint ",
+    "lint:liquid": "liquid-linter layout sections snippets assets templates --custom-tag section schema"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Blendtec/blendtec-shopify-theme.git"
+  },
+  "author": "devteam@blendtec.com",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/Blendtec/blendtec-shopify-theme/issues"
+  },
+  "homepage": "https://github.com/Blendtec/blendtec-shopify-theme#readme",
+  "devDependencies": {
+    "@shopify/theme-lint": "^2.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.9.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "gulp": "^3.9.1",
+    "gulp-html-lint": "0.0.2",
+    "htmllint-cli": "0.0.6",
+    "jslint": "^0.12.0",
+    "liquid-linter-cli": "^0.3.0"
+  }
+}

--- a/themekit_ignores
+++ b/themekit_ignores
@@ -1,8 +1,17 @@
 # plain file names
 config/settings_data.json
+.htmllintrc
+.travis.yml
+.gitignore
+.eslintrc.json
+gulpFile.js
+how-to-use.txt
+npm-debug.log
+watchTheme.sh
 
 # globs
 *.png
+node_modules/*
 
 # regex
 /\.(txt|gif|bat)$/


### PR DESCRIPTION
BUild tools are not wired to anything and must be run manually until we get caught up a little on
the amount of style debt we have.

This is really just a rough start. the liquid files kind of throw a wrench into things. the html linting seems to be working well but we have so many errors that it's overwhelming so for now we just need to lint any file we touch individually.  I've added tasks in the npm package so you can do  `$ npm run lint:htmlFile <name of file>` and it will lint that single file. 