### PR TITLE
fix(cart.liquid): Remove AmazonPay button

### DIFF
--- a/templates/cart.liquid
+++ b/templates/cart.liquid
@@ -149,10 +149,6 @@
               <input type="submit" name="update" class="btn update-cart small--btn--full" value="{{ 'cart.general.update' | t }}">
 
               <input type="submit" name="checkout" class="btn small--btn--full" value="{{ 'cart.general.checkout' | t }}">
-
-            {% if additional_checkout_buttons %}
-              <div class='cart__extra'>{{ content_for_additional_checkout_buttons }}</div>
-            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Amazon Pay doesn't have the requisite script to run correctly on this page.